### PR TITLE
652: Arbitrary expressions in empty are allowed in PHP 5.5 only

### DIFF
--- a/includes/gdpr-integration/gdpr-privacy-options.php
+++ b/includes/gdpr-integration/gdpr-privacy-options.php
@@ -103,13 +103,15 @@ class WPAS_Privacy_Option {
 
 			case 'add_user_consent':
 
-				$_status = (isset( $_GET['_status'] ) && !empty( isset( $_GET['_status'] ) ))? sanitize_text_field( $_GET['_status'] ): '';
-				$consent = ( isset( $_GET['_consent'] ) && !empty( isset( $_GET['_consent'] ) ) )? sanitize_text_field( $_GET['_consent'] ): '';
-				if( empty( $_status ) || empty( $consent ) ){
+				// $_status = (isset( $_GET['_status'] ) && !empty( isset( $_GET['_status'] ) ))? sanitize_text_field( $_GET['_status'] ): '';
+				$_status = ( isset( $_GET['_status'] ) && $_GET['_status'] ) ? sanitize_text_field( $_GET['_status'] ) : '';
+				// $consent = ( isset( $_GET['_consent'] ) && !empty( isset( $_GET['_consent'] ) ) )? sanitize_text_field( $_GET['_consent'] ): '';
+				$consent = ( isset( $_GET['_consent'] ) && $_GET['_consent'] ) ? sanitize_text_field( $_GET['_consent'] ) : '';
+				if ( empty( $_status ) || empty( $consent ) ) {
 					return false;
 				}
 				// Check for results
-				if (!empty($authors)) {
+				if ( ! empty( $authors ) ) {
 
 				    // loop through each author
 				    foreach ($authors as $author) {

--- a/readme.txt
+++ b/readme.txt
@@ -447,6 +447,11 @@ There are several factors that can influence e-mail notifications delivery. Plea
 
 == Changelog ==
 
+= 6.0.15 =
+
+* Fix
+  * Fixed stability vulnerability
+
 = 6.0.14 =
 
 * Fix


### PR DESCRIPTION
#652: Arbitrary expressions in empty are allowed in PHP 5.5 only
* Added changelog entry